### PR TITLE
ルーム検索画面のリファクタリング

### DIFF
--- a/DJSystemiOS/Common/APIClient/URLBuilder.swift
+++ b/DJSystemiOS/Common/APIClient/URLBuilder.swift
@@ -5,6 +5,7 @@ enum URLBuilder {
     case musicTop(roomId: String)
     case musicSearch(roomId: String, query: String)
     case requestMusic(roomId: String)
+    case getRoom(roomId: String)
 
     var endpoint: URL {
         let baseURL = "http://example.com"
@@ -17,6 +18,8 @@ enum URLBuilder {
             return URL(string: "\(baseURL)/room/\(roomId)/music/search?q=\(query)")!
         case .requestMusic(let roomId):
             return URL(string: "\(baseURL)/room/\(roomId)/request")!
+        case .getRoom(let roomId):
+            return URL(string: "\(baseURL)/room/\(roomId)")!
         }
     }
 }
@@ -26,6 +29,7 @@ enum Endpoint {
     case musicTop(roomId: String)
     case musicSearch(roomId: String, query: String)
     case requestMusic(roomId: String)
+    case getRoom(roomId: String)
 
     var path: String {
         switch self {
@@ -37,6 +41,8 @@ enum Endpoint {
             return "/room/\(roomId)/music/search?q=\(query)"
         case .requestMusic(let roomId):
             return "/room/\(roomId)/request"
+        case .getRoom(let roomId):
+            return "/room/\(roomId)"
         }
     }
 }

--- a/DJSystemiOS/Common/PageTransition/Presenter/SearchRoomPresenter.swift
+++ b/DJSystemiOS/Common/PageTransition/Presenter/SearchRoomPresenter.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+protocol SearchRoomPresenterProtocol {
+    func transitionToRoomOverviewPage(roomOverview: RoomOverview)
+}
+
+final class SearchRoomPresenter: SearchRoomPresenterProtocol {
+    private let router: SearchRoomRouterProtocol
+
+    init(router: SearchRoomRouterProtocol) {
+        self.router = router
+    }
+
+    func transitionToRoomOverviewPage(roomOverview: RoomOverview) {
+        router.transitionToRoomOverviewPage(roomOverview: roomOverview)
+    }
+}

--- a/DJSystemiOS/Common/PageTransition/Router/SearchRoomRouter.swift
+++ b/DJSystemiOS/Common/PageTransition/Router/SearchRoomRouter.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+protocol SearchRoomRouterProtocol: AnyObject {
+    func transitionToRoomOverviewPage(roomOverview: RoomOverview)
+}
+final class SearchRoomRouter: SearchRoomRouterProtocol {
+    private(set) weak var controller: SearchRoomPageViewController!
+
+    init(controller: SearchRoomPageViewController) {
+        self.controller = controller
+    }
+
+    func transitionToRoomOverviewPage(roomOverview: RoomOverview) {
+        // 遷移先のRoomOverViewController
+        let roomOverviewController = RoomOverviewViewController(roomOverview: roomOverview)
+        controller.inject(presenter: SearchRoomPresenter(router: self))
+        // 画面遷移
+        controller.navigationController?.pushViewController(roomOverviewController, animated: true)
+    }
+}

--- a/DJSystemiOS/Common/PageTransition/Transitioner.swift
+++ b/DJSystemiOS/Common/PageTransition/Transitioner.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+protocol Transitioner: AnyObject where Self: UIViewController {
+    func pushViewController(_ viewController: UIViewController, animated: Bool)
+    func present(viewController: UIViewController,
+                 animated: Bool,
+                 completion: (() -> ())?)
+    func dismiss(animated: Bool)
+}
+
+extension Transitioner {
+    func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        guard let nc = navigationController else { return }
+        nc.pushViewController(viewController, animated: animated)
+    }
+    func present(viewController: UIViewController, animated: Bool, completion: (() -> ())? = nil) {
+        present(viewController, animated: animated, completion: completion)
+    }
+    func dismiss(animated: Bool) {
+        dismiss(animated: animated)
+    }
+}

--- a/DJSystemiOS/Features/Room/API/GetRoom.swift
+++ b/DJSystemiOS/Features/Room/API/GetRoom.swift
@@ -15,7 +15,7 @@ protocol GetRoomAPIProtocol {
 }
 
 extension Room.API: GetRoomAPIProtocol {
-    func getRoom(id: String) async throws -> Result<GetRoomResponse, APIClientError> {
+    func getRoom(id: String) async -> Result<GetRoomResponse, APIClientError> {
         let client = APIClient(baseURL: Environment.BaseAPIURL)
         let result = await client.get(from: .getRoom(roomId: id), dataType: Room.API.GetRoomResponse.self)
         return result

--- a/DJSystemiOS/Features/Room/API/GetRoom.swift
+++ b/DJSystemiOS/Features/Room/API/GetRoom.swift
@@ -1,33 +1,24 @@
 import Foundation
 import Moya
 
+extension Room.API {
+    struct GetRoomResponse: Codable {
+        let id: String
+        let name: String
+        let description: String
+        let roomCooltime: Int
+    }
+}
+
 protocol GetRoomAPIProtocol {
-    func getRoom(id: String) async throws -> RoomOverview
+    func getRoom(id: String) async throws -> Result<Room.API.GetRoomResponse, APIClientError>
 }
 
 extension Room.API: GetRoomAPIProtocol {
-    func getRoom(id: String) async throws -> RoomOverview {
-        return try await withCheckedThrowingContinuation { continuation in
-            Room.API.provider.request(.getRoom(id: id)) { result in
-                switch result {
-                case let .success(response):
-                    do {
-                        // Status Code 200...299 の判定
-                        if response.statusCode < 200 || response.statusCode >= 300 {
-                            continuation.resume(returning: RoomOverview(id: "", name: "", description: ""))
-                        } else {
-                            let filteredResponse = try response.filterSuccessfulStatusCodes()
-                            let roomOverview = try filteredResponse.map(RoomOverview.self)
-                            continuation.resume(returning: roomOverview)
-                        }
-                    } catch let error {
-                        continuation.resume(throwing: error)
-                    }
-                case let .failure(error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+    func getRoom(id: String) async throws -> Result<GetRoomResponse, APIClientError> {
+        let client = APIClient(baseURL: Environment.BaseAPIURL)
+        let result = await client.get(from: .getRoom(roomId: id), dataType: Room.API.GetRoomResponse.self)
+        return result
     }
 }
 

--- a/DJSystemiOS/Pages/RoomOverviewPage/RoomOverviewPageView.swift
+++ b/DJSystemiOS/Pages/RoomOverviewPage/RoomOverviewPageView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct RoomOverviewPageView: View {
 
-    @SwiftUI.Environment(\.dismiss) var dismiss
     weak var controller: RoomOverviewControllerProtocol?
     @ObservedObject var dataSource: DataSource
 

--- a/DJSystemiOS/Pages/RoomOverviewPage/RoomOverviewPageView.swift
+++ b/DJSystemiOS/Pages/RoomOverviewPage/RoomOverviewPageView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct RoomOverviewPageView: View {
 
-    @Environment(\.dismiss) var dismiss
+    @SwiftUI.Environment(\.dismiss) var dismiss
     weak var controller: RoomOverviewControllerProtocol?
     @ObservedObject var dataSource: DataSource
 

--- a/DJSystemiOS/Pages/SearchRoomPage/Router/SearchRoomRouter.swift
+++ b/DJSystemiOS/Pages/SearchRoomPage/Router/SearchRoomRouter.swift
@@ -1,20 +1,14 @@
 import UIKit
 
 protocol SearchRoomRouterProtocol: AnyObject {
-    func transitionToRoomOverviewPage(roomOverview: RoomOverview)
+    func transitionToRoomOverviewPage(_ navigationController: UINavigationController, roomOverview: RoomOverview)
 }
 
 final class SearchRoomRouter: SearchRoomRouterProtocol {
-    private(set) weak var controller: SearchRoomPageViewController!
-
-    init(controller: SearchRoomPageViewController) {
-        self.controller = controller
-    }
-
-    func transitionToRoomOverviewPage(roomOverview: RoomOverview) {
+    func transitionToRoomOverviewPage(_ navigationController: UINavigationController, roomOverview: RoomOverview) {
         // 遷移先のRoomOverViewController
         let roomOverviewController = RoomOverviewViewController(roomOverview: roomOverview)
         // 画面遷移
-        controller.navigationController?.pushViewController(roomOverviewController, animated: true)
+        navigationController.pushViewController(roomOverviewController, animated: true)
     }
 }

--- a/DJSystemiOS/Pages/SearchRoomPage/Router/SearchRoomRouter.swift
+++ b/DJSystemiOS/Pages/SearchRoomPage/Router/SearchRoomRouter.swift
@@ -3,6 +3,7 @@ import UIKit
 protocol SearchRoomRouterProtocol: AnyObject {
     func transitionToRoomOverviewPage(roomOverview: RoomOverview)
 }
+
 final class SearchRoomRouter: SearchRoomRouterProtocol {
     private(set) weak var controller: SearchRoomPageViewController!
 
@@ -13,7 +14,6 @@ final class SearchRoomRouter: SearchRoomRouterProtocol {
     func transitionToRoomOverviewPage(roomOverview: RoomOverview) {
         // 遷移先のRoomOverViewController
         let roomOverviewController = RoomOverviewViewController(roomOverview: roomOverview)
-        controller.inject(presenter: SearchRoomPresenter(router: self))
         // 画面遷移
         controller.navigationController?.pushViewController(roomOverviewController, animated: true)
     }

--- a/DJSystemiOS/Pages/SearchRoomPage/SearchRoomPageView.swift
+++ b/DJSystemiOS/Pages/SearchRoomPage/SearchRoomPageView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
-struct HomePageView: View {
-    weak var controller: HomePageControllerProtocol?
+struct SearchRoomPageView: View {
+    weak var controller: SearchRoomPageControllerProtocol?
     @ObservedObject var dataSource: DataSource
 
-    init(controller: HomePageControllerProtocol) {
+    init(controller: SearchRoomPageControllerProtocol) {
         self.controller = controller
         self.dataSource = controller.state
     }
@@ -74,7 +74,7 @@ struct HomePageView: View {
     }
 }
 
-extension HomePageView {
+extension SearchRoomPageView {
     class DataSource: ObservableObject {
         @Published var searchQuery = ""
         @Published var currentRoom: RoomOverview?

--- a/DJSystemiOS/Pages/SearchRoomPage/SearchRoomPageView.swift
+++ b/DJSystemiOS/Pages/SearchRoomPage/SearchRoomPageView.swift
@@ -49,13 +49,6 @@ struct SearchRoomPageView: View {
                 Text("検索する")
                     .frame(maxWidth: .infinity, minHeight: 42)
             }
-            .alert("ルームが見つかりませんでした", isPresented: $dataSource.shouldShowAlert) {
-                Button("OK") {
-                    // 了解ボタンが押された時の処理
-                }
-            } message: {
-                Text("IDが間違っていないか確認してください")
-            }
             .background(Color.pink)
             .foregroundColor(Color(.white))
             .font(.system(size: 12, weight: .bold, design: .default))
@@ -78,7 +71,6 @@ extension SearchRoomPageView {
     class DataSource: ObservableObject {
         @Published var searchQuery = ""
         @Published var currentRoom: RoomOverview?
-        @Published var shouldShowAlert = false
         @Published var showResultText = false
     }
 }

--- a/DJSystemiOS/Pages/SearchRoomPage/SearchRoomPageViewController.swift
+++ b/DJSystemiOS/Pages/SearchRoomPage/SearchRoomPageViewController.swift
@@ -2,13 +2,13 @@ import PKHUD
 import SwiftUI
 import UIKit
 
-protocol HomePageControllerProtocol: AnyObject {
+protocol SearchRoomPageControllerProtocol: AnyObject {
     func searchRoom(byId id: String) async throws
-    var state: HomePageView.DataSource { get set }
+    var state: SearchRoomPageView.DataSource { get set }
 }
 
-final class HomePageViewController: UIViewController {
-    @ObservedObject var state: HomePageView.DataSource = .init()
+final class SearchRoomPageViewController: UIViewController {
+    @ObservedObject var state: SearchRoomPageView.DataSource = .init()
     // TODO: 後でletに変える
     var roomAPI: GetRoomAPIProtocol = Room.API()
 
@@ -24,7 +24,7 @@ final class HomePageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let homePage = HomePageView(controller: self)
+        let homePage = SearchRoomPageView(controller: self)
         let hostingVC = UIHostingController(rootView: homePage)
         addChild(hostingVC)
         view.addSubview(hostingVC.view)
@@ -33,7 +33,7 @@ final class HomePageViewController: UIViewController {
     }
 }
 
-extension HomePageViewController: HomePageControllerProtocol {
+extension SearchRoomPageViewController: SearchRoomPageControllerProtocol {
     func searchRoom(byId id: String) async throws {
         do {
             // ローディング開始

--- a/DJSystemiOS/Pages/SearchRoomPage/SearchRoomPageViewController.swift
+++ b/DJSystemiOS/Pages/SearchRoomPage/SearchRoomPageViewController.swift
@@ -49,9 +49,9 @@ extension SearchRoomPageViewController: SearchRoomPageControllerProtocol {
                     // 表示結果を表示する
                     state.showResultText = true
                 }
-                let router = SearchRoomRouter(controller: self)
+                let router = SearchRoomRouter()
                 // Routerを使った画面遷移
-                router.transitionToRoomOverviewPage(roomOverview: roomOverview)
+                router.transitionToRoomOverviewPage(self.navigationController!, roomOverview: roomOverview)
                 // ローディング終了
                 HUD.hide()
             // Roomが見つからなかった時

--- a/DJSystemiOS/Pages/SearchRoomPage/SearchRoomPageViewController.swift
+++ b/DJSystemiOS/Pages/SearchRoomPage/SearchRoomPageViewController.swift
@@ -11,19 +11,14 @@ final class SearchRoomPageViewController: UIViewController {
     @ObservedObject var state: SearchRoomPageView.DataSource = .init()
     // TODO: 後でletに変える
     var roomAPI: GetRoomAPIProtocol = Room.API()
-    var presenter: SearchRoomPresenterProtocol!
-    func inject(presenter: SearchRoomPresenterProtocol) {
-        self.presenter = presenter
-    }
 
     init(roomAPI: GetRoomAPIProtocol) {
-        super.init(nibName: nil, bundle: nil)
         self.roomAPI = roomAPI
+        super.init(nibName: nil, bundle: nil)
     }
 
     required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        self.roomAPI = Room.API()
+        fatalError("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {
@@ -54,8 +49,9 @@ extension SearchRoomPageViewController: SearchRoomPageControllerProtocol {
                     // 表示結果を表示する
                     state.showResultText = true
                 }
+                let router = SearchRoomRouter(controller: self)
                 // Routerを使った画面遷移
-                presenter.transitionToRoomOverviewPage(roomOverview: roomOverview)
+                router.transitionToRoomOverviewPage(roomOverview: roomOverview)
                 // ローディング終了
                 HUD.hide()
             // Roomが見つからなかった時

--- a/DJSystemiOS/Pages/SearchRoomPage/SearchRoomPageViewController.swift
+++ b/DJSystemiOS/Pages/SearchRoomPage/SearchRoomPageViewController.swift
@@ -50,8 +50,9 @@ extension SearchRoomPageViewController: SearchRoomPageControllerProtocol {
                     state.showResultText = true
                 }
                 let router = SearchRoomRouter()
+                guard let navigationController = self.navigationController else { return }
                 // Routerを使った画面遷移
-                router.transitionToRoomOverviewPage(self.navigationController!, roomOverview: roomOverview)
+                router.transitionToRoomOverviewPage(navigationController, roomOverview: roomOverview)
                 // ローディング終了
                 HUD.hide()
             // Roomが見つからなかった時


### PR DESCRIPTION
## issue番号

resolve #48 

## やったこと
- HomePageからSearchRoomPageに名前を変更
- APIとの通信周りをAPIClientに書き換える
- AlertをViewControllerから表示するようにする
- Routerパターンを使用する


## 補足(あれば)
environmentの記述において、下記のようにする必要があったので変更しておきました
```
@SwiftUI.Environment(\.dismiss) var dismiss
```

## TODO
- [x] Reviewersを設定しました
- [x] Assigneesを設定しました
- [x] issue番号を記載しました
